### PR TITLE
Remove value override for hipchat notify

### DIFF
--- a/src/Namshi/Notificator/Notification/Handler/HipChat.php
+++ b/src/Namshi/Notificator/Notification/Handler/HipChat.php
@@ -35,7 +35,7 @@ class HipChat implements HandlerInterface
      */
     public function handle(NotificationInterface $notification)
     {        
-        $notify = $notification->getParameter('hipchat_notify') ?: true;
+        $notify = $notification->getParameter('hipchat_notify');
         $color  = $notification->getParameter('hipchat_color') ?: HipChatClient::COLOR_YELLOW;
         $format = $notification->getParameter('hipchat_message_format') ?: HipChatClient::FORMAT_TEXT;
                     
@@ -43,7 +43,7 @@ class HipChat implements HandlerInterface
             $notification->getHipChatRoom(),
             $notification->getHipChatSenderId(),
             $notification->getMessage(),
-            $notify,
+            isset($notify) ? $notify : true ,
             $color,
             $format
         );


### PR DESCRIPTION
If that parameter `hipchat_notify` is set to `false` (i.e don't notify) then the setting will override the value to `true`