### PR TITLE
Fix handling of multi-word message

### DIFF
--- a/src/Namshi/Notificator/Notification/Handler/NotifySend.php
+++ b/src/Namshi/Notificator/Notification/Handler/NotifySend.php
@@ -71,11 +71,9 @@ class NotifySend implements HandlerInterface
                 $command .= $key;
                 $command .= "=";
                 $command .= $value;
-                $command .= "";
             }
         }
-        $command .= " " . $notification->getMessage();
-        return sprintf(self::NOTIFY_SEND_COMMAND.' %s', $command);
+        return sprintf(self::NOTIFY_SEND_COMMAND.' %s "%s"', $command, $notification->getMessage());
     }
 
     /**


### PR DESCRIPTION
In my case (Ubuntu), I ran into a problem where the message passed had multiple words and notify-send threw "Invalid number of options" error ... the solution was to put "" around the message.