### PR TITLE
Bug fix when using it as Symfony Bundle

### DIFF
--- a/src/Namshi/Notificator/Symfony/DependencyInjection/NamshiNotificatorExtension.php
+++ b/src/Namshi/Notificator/Symfony/DependencyInjection/NamshiNotificatorExtension.php
@@ -19,7 +19,7 @@ class NamshiNotificatorExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/./Resources/config'));
         $loader->load('services.yml');
     }
 }


### PR DESCRIPTION
Hello,
This error occurs when using the library as a Symfony Bundle

`[InvalidArgumentException]
  The file "services.yml" does not exist (in: vendor/namshi/notificator/src/Namshi/Notificator/Symfony/De
  pendencyInjection/../Resources/config).
`